### PR TITLE
Add path planner module with A* example

### DIFF
--- a/notebooks/a_star_demo.ipynb
+++ b/notebooks/a_star_demo.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A* Planner Demo\n",
+    "\n",
+    "This notebook demonstrates how to use `AStarPlanner` with a simple occupancy grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from path_planner import AStarPlanner\n",
+    "from path_planner.utils import plot_map, plot_path\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Create simple 10x10 grid with an obstacle wall\n",
+    "grid = np.zeros((10, 10), dtype=int)\n",
+    "grid[5, 1:8] = 1\n",
+    "start = (2, 2)\n",
+    "goal = (8, 8)\n",
+    "\n",
+    "planner = AStarPlanner()\n",
+    "path = planner.plan(start, goal, grid)\n",
+    "\n",
+    "plt.figure(figsize=(5,5))\n",
+    "plot_map(grid)\n",
+    "plot_path(path)\n",
+    "plt.show()\n",
+    "print(\"Path:\", path)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/path_planner/__init__.py
+++ b/path_planner/__init__.py
@@ -1,0 +1,6 @@
+"""Path planning algorithms for surface vessels."""
+
+from .base_planner import PathPlanner
+from .a_star_planner import AStarPlanner
+
+__all__ = ["PathPlanner", "AStarPlanner"]

--- a/path_planner/a_star_planner.py
+++ b/path_planner/a_star_planner.py
@@ -1,0 +1,72 @@
+"""Grid-based A* planner implementation."""
+
+from __future__ import annotations
+
+import heapq
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+
+from .base_planner import PathPlanner
+
+
+class AStarPlanner(PathPlanner):
+    """A* path planner for 2D occupancy grids."""
+
+    def __init__(self):
+        pass
+
+    def _heuristic(self, a: Tuple[int, int], b: Tuple[int, int]) -> float:
+        return float(np.hypot(b[0] - a[0], b[1] - a[1]))
+
+    def _neighbors(self, node: Tuple[int, int], grid: np.ndarray) -> List[Tuple[int, int]]:
+        rows, cols = grid.shape
+        dirs = [
+            (-1, 0),
+            (1, 0),
+            (0, -1),
+            (0, 1),
+            (-1, -1),
+            (-1, 1),
+            (1, -1),
+            (1, 1),
+        ]
+        result = []
+        for dr, dc in dirs:
+            r, c = node[0] + dr, node[1] + dc
+            if 0 <= r < rows and 0 <= c < cols and grid[r, c] == 0:
+                result.append((r, c))
+        return result
+
+    def plan(
+        self, start: Tuple[int, int], goal: Tuple[int, int], map_data: Any
+    ) -> List[Tuple[int, int]]:
+        grid = np.asarray(map_data)
+        open_set = []
+        heapq.heappush(open_set, (0 + self._heuristic(start, goal), 0, start))
+        came_from: Dict[Tuple[int, int], Tuple[int, int]] = {}
+        g_score: Dict[Tuple[int, int], float] = {start: 0.0}
+        closed = set()
+
+        while open_set:
+            _, cost, current = heapq.heappop(open_set)
+            if current in closed:
+                continue
+            if current == goal:
+                # reconstruct path
+                path = [current]
+                while current in came_from:
+                    current = came_from[current]
+                    path.append(current)
+                path.reverse()
+                return path
+            closed.add(current)
+            for neighbor in self._neighbors(current, grid):
+                tentative_g = g_score[current] + self._heuristic(current, neighbor)
+                if neighbor not in g_score or tentative_g < g_score[neighbor]:
+                    g_score[neighbor] = tentative_g
+                    f = tentative_g + self._heuristic(neighbor, goal)
+                    heapq.heappush(open_set, (f, tentative_g, neighbor))
+                    came_from[neighbor] = current
+        return []
+

--- a/path_planner/base_planner.py
+++ b/path_planner/base_planner.py
@@ -1,0 +1,32 @@
+"""Abstract interface for path planners."""
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Tuple, Any, List
+
+
+class PathPlanner(ABC):
+    """Abstract base class for path planners."""
+
+    @abstractmethod
+    def plan(
+        self, start: Tuple[int, int], goal: Tuple[int, int], map_data: Any
+    ) -> List[Tuple[int, int]]:
+        """Plan a path from start to goal on the given map.
+
+        Parameters
+        ----------
+        start : Tuple[int, int]
+            Start position as (row, col).
+        goal : Tuple[int, int]
+            Goal position as (row, col).
+        map_data : Any
+            Map representation used by the planner. Typically a 2D occupancy grid.
+
+        Returns
+        -------
+        List[Tuple[int, int]]
+            Sequence of grid coordinates from start to goal inclusive. Empty if
+            no path could be found.
+        """
+        pass
+

--- a/path_planner/dubins_planner.py
+++ b/path_planner/dubins_planner.py
@@ -1,0 +1,15 @@
+"""Placeholder for Dubins path planner."""
+
+from typing import Any, List, Tuple
+
+from .base_planner import PathPlanner
+
+
+class DubinsPlanner(PathPlanner):
+    """Curvature-constrained planner (not implemented)."""
+
+    def plan(
+        self, start: Tuple[int, int], goal: Tuple[int, int], map_data: Any
+    ) -> List[Tuple[int, int]]:
+        raise NotImplementedError("Dubins planner not implemented yet")
+

--- a/path_planner/utils.py
+++ b/path_planner/utils.py
@@ -1,0 +1,26 @@
+"""Utility functions for path planning."""
+
+from typing import Iterable, Tuple, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_map(grid: np.ndarray) -> None:
+    """Plot a binary occupancy grid."""
+    plt.imshow(grid, cmap="Greys", origin="lower")
+    plt.xlabel("x")
+    plt.ylabel("y")
+    plt.title("Occupancy Grid")
+
+
+def plot_path(path: Iterable[Tuple[int, int]]) -> None:
+    """Plot a sequence of grid coordinates on the current figure."""
+    if not path:
+        return
+    pts = np.array(list(path))
+    plt.plot(pts[:, 1], pts[:, 0], "r-", linewidth=2)
+    plt.plot(pts[0, 1], pts[0, 0], "go", label="start")
+    plt.plot(pts[-1, 1], pts[-1, 0], "bx", label="goal")
+    plt.legend()
+


### PR DESCRIPTION
## Summary
- add `path_planner` package with abstract base planner
- implement A* grid-based planner
- provide plotting helpers for map and path
- include a demonstration notebook

## Testing
- `python -m py_compile path_planner/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6845b313ad08832e9bf1e9958cf0fe2f