### PR TITLE
Add path smoothing utility

### DIFF
--- a/examples/a_star_example.py
+++ b/examples/a_star_example.py
@@ -10,7 +10,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from path_planner import AStarPlanner
-from path_planner.utils import plot_map, plot_path
+from path_planner.utils import plot_map, plot_path, smooth_path
 
 
 def main():
@@ -24,13 +24,15 @@ def main():
 
     planner = AStarPlanner()
     path = planner.plan(start, goal, grid)
+    smoothed = smooth_path(path, smoothness=0.5)
 
     print(f"Path length: {len(path)}")
     print("Path:", path)
+    print("Smoothed path:", smoothed)
 
     plt.figure(figsize=(5, 5))
     plot_map(grid)
-    plot_path(path)
+    plot_path(smoothed)
     plt.show()
 
 

--- a/path_planner/__init__.py
+++ b/path_planner/__init__.py
@@ -2,5 +2,6 @@
 
 from .base_planner import PathPlanner
 from .a_star_planner import AStarPlanner
+from .utils import plot_map, plot_path, smooth_path
 
-__all__ = ["PathPlanner", "AStarPlanner"]
+__all__ = ["PathPlanner", "AStarPlanner", "plot_map", "plot_path", "smooth_path"]

--- a/path_planner/utils.py
+++ b/path_planner/utils.py
@@ -24,3 +24,46 @@ def plot_path(path: Iterable[Tuple[int, int]]) -> None:
     plt.plot(pts[-1, 1], pts[-1, 0], "bx", label="goal")
     plt.legend()
 
+
+def smooth_path(
+    path: List[Tuple[int, int]], smoothness: float, iterations: int = 50
+) -> List[Tuple[float, float]]:
+    """Return a smoothed version of a grid path.
+
+    Parameters
+    ----------
+    path : List[Tuple[int, int]]
+        Discrete path returned by a planner.
+    smoothness : float
+        Value between 0 and 1 specifying how much to smooth the path.
+        ``0`` returns the original path while ``1`` applies the maximum
+        smoothing.
+    iterations : int, optional
+        Number of smoothing iterations to perform.
+
+    Returns
+    -------
+    List[Tuple[float, float]]
+        The smoothed path coordinates.
+    """
+
+    if not path or smoothness <= 0.0:
+        return list(path)
+
+    smoothness = float(np.clip(smoothness, 0.0, 1.0))
+
+    pts = np.asarray(path, dtype=float)
+    new_pts = pts.copy()
+
+    weight_data = 1.0 - smoothness
+    weight_smooth = smoothness
+
+    for _ in range(iterations):
+        for i in range(1, len(pts) - 1):
+            new_pts[i] += weight_data * (pts[i] - new_pts[i])
+            new_pts[i] += weight_smooth * (
+                new_pts[i - 1] + new_pts[i + 1] - 2.0 * new_pts[i]
+            )
+
+    return [tuple(p) for p in new_pts]
+

--- a/tests/test_smooth_path.py
+++ b/tests/test_smooth_path.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import numpy as np
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from path_planner import AStarPlanner
+from path_planner.utils import smooth_path
+
+
+def _create_grid():
+    grid = np.zeros((7, 7), dtype=int)
+    grid[3, :5] = 1
+    return grid
+
+
+def test_smooth_path_identity():
+    grid = _create_grid()
+    planner = AStarPlanner()
+    start, goal = (0, 0), (6, 6)
+    path = planner.plan(start, goal, grid)
+
+    smoothed = smooth_path(path, smoothness=0.0)
+    assert smoothed == path
+
+
+def test_smooth_path_changes():
+    grid = _create_grid()
+    planner = AStarPlanner()
+    start, goal = (0, 0), (6, 6)
+    path = planner.plan(start, goal, grid)
+
+    smoothed = smooth_path(path, smoothness=1.0)
+    assert smoothed[0] == path[0]
+    assert smoothed[-1] == path[-1]
+    assert smoothed != path


### PR DESCRIPTION
## Summary
- implement `smooth_path` for iterative path smoothing
- expose plotting and smoothing utilities in the package
- demonstrate path smoothing in `a_star_example.py`
- test that smoothing keeps endpoints and allows adjustable smoothing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684610744cdc832e81e89875e2403fa2